### PR TITLE
Use http1.1 from curl not to get compressed output

### DIFF
--- a/tweet.sh
+++ b/tweet.sh
@@ -1246,6 +1246,7 @@ call_api() {
          --header \"$headers\" \
          --data \"$params\" \
          --silent \
+         --http1.1 \
          $debug_params \
          $url"
   fi


### PR DESCRIPTION
Compressed data is output with recent curl. This problem happens because of
the following logic.

 1. Recent curl uses http2 by default when sending requests to twitter API
 2. twitter API always returns gzip-compressed data even if any encoding is
    prohibited by Accept-Encoding header(*1).
 3. curl doesn't handle Content-Encoding when --compressed option is not set

*1) When using http1.1, twitter API doesn't compress the output by default

For more information about this twitter API's problem, please see
the following URL.

https://twittercommunity.com/t/twitter-api-doesnt-look-header-accept-encoding-identity/56571

* Step to reproduce

===============================================================================
$ ./tweet.sh showme | file -
===============================================================================

Probably this problem happens with any other subcommands.

* Actual result (with 62ad663098e3be24aab43a25303ef2a273fdfb23)

===============================================================================
$ ./tweet.sh showme | file -
/dev/stdin: gzip compressed data, from FAT filesystem (MS-DOS, OS/2, NT)
$
===============================================================================

* Expected result

===============================================================================
$ ./tweet.sh showme | file -
/dev/stdin: ASCII text, with very long lines, with no line terminators
$
===============================================================================

* Software environment

curl 7.50.1 (x86_64-pc-linux-gnu) libcurl/7.50.1 GnuTLS/3.5.7 zlib/1.2.8 libidn/1.33 libssh2/1.7.0 nghttp2/1.17.0 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets

I confirmed this problem didn't happen with curl 7.35.0. This version uses
http1.1 by default.