### PR TITLE
Add location option to post()

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ This will be useful if you want to get both informations `whoami` and `language`
 
  * Parameters
    * `-m`: comma-separated list of uploaded media IDs. See also the `upload` command.
+   * `-l`: add location to tweet. (optional)
    * All rest arguments: the body of a new tweet to be posted. If you don't specify no extra parameters, this command reads posting body from the standard input.
  * Standard output
    * [A JSON string of the posted tweet](https://dev.twitter.com/rest/reference/post/statuses/update).
@@ -332,6 +333,7 @@ This will be useful if you want to get both informations `whoami` and `language`
    $ ./tweet.sh post 何らかのつぶやき
    $ ./tweet.sh tweet @friend Good morning.
    $ ./tweet.sh tw -m 123,456,789 My Photos!
+   $ ./tweet.sh post -l A tweet with location
    $ cat body.txt | ./tweet.sh post
    ~~~
 

--- a/tweet.sh
+++ b/tweet.sh
@@ -353,6 +353,7 @@ Usage:
   ./tweet.sh post 何らかのつぶやき
   ./tweet.sh tweet Hello
   ./tweet.sh tw Hi
+  ./tweet.sh post -l A tweet with location
   cat body.txt | ./tweet.sh post
 FIN
       ;;
@@ -1014,20 +1015,26 @@ post() {
   ensure_available
 
   local media_params=''
+  local location_params=''
 
   local OPTIND OPTARG OPT
-  while getopts m: OPT
+  while getopts m:l OPT
   do
     case $OPT in
       m )
         media_params="media_ids=$OPTARG"
         shift 2
         ;;
+      l )
+        location_params="$(curl --silent  http://geoip.nekudo.com/api | jq --raw-output '.location | "lat \(.latitude)\nlong \(.longitude)"')"
+        shift 1
+        ;;
     esac
   done
 
   local params="$(cat << FIN
 status $(posting_body $*)
+$location_params
 $media_params
 FIN
   )"


### PR DESCRIPTION
I wanted to add location to tweets. 

It might have the following problems: 

* Adds a location api dependency 
* Errors might not be handled correctly 
* Since the primary use of this script is for _bot_'s, it might be more useful to specify lat/long in a comma separated list. 
* Might need to add parallel functionality to retweet() 

Wow, now that I've actually listed out the potential issues, I'm reconsidering even submitting. 

I will anyways, we can hash out whither you even _want_ to add locations to tweets. 